### PR TITLE
Add the stx-basic bundle as the neutron dependency.

### DIFF
--- a/files/rpms-clear/neutron
+++ b/files/rpms-clear/neutron
@@ -1,0 +1,1 @@
+stx-basic


### PR DESCRIPTION
Just to make the swupd_install work on Clearlinux devstack.

Signed-off-by: Yan Chen <yan.chen@intel.com>