### PR TITLE
Ignore package install and uninstall on Clearlinux.

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -1357,6 +1357,8 @@ function uninstall_package {
         sudo ${YUM:-yum} remove -y "$@" ||:
     elif is_suse; then
         sudo zypper remove -y "$@" ||:
+    elif is_clearlinux; then
+	echo "don't uninstall packages on clearlinux now"
     else
         exit_distro_not_supported "uninstalling packages"
     fi

--- a/lib/cinder
+++ b/lib/cinder
@@ -442,6 +442,10 @@ function init_cinder {
 function install_cinder {
     git_clone $CINDER_REPO $CINDER_DIR $CINDER_BRANCH
     setup_develop $CINDER_DIR
+    if is_clearlinux; then
+	return
+    fi
+
     if [[ "$CINDER_ISCSI_HELPER" == "tgtadm" ]]; then
         install_package tgt
     elif [[ "$CINDER_ISCI_HELPER" == "lioadm" ]]; then

--- a/lib/neutron
+++ b/lib/neutron
@@ -359,7 +359,11 @@ function install_neutron_new {
 
     # L3 service requires radvd
     if is_service_enabled neutron-l3; then
-        install_package radvd
+	if is_clearlinux; then
+	    install_package openstack-common
+	else
+    	    install_package radvd
+	fi
     fi
 
     if is_service_enabled neutron-agent neutron-dhcp neutron-l3; then

--- a/lib/neutron-legacy
+++ b/lib/neutron-legacy
@@ -440,7 +440,11 @@ function install_mutnauq {
 function install_neutron_agent_packages_mutnauq {
     # radvd doesn't come with the OS. Install it if the l3 service is enabled.
     if is_service_enabled q-l3; then
-        install_package radvd
+	if is_clearlinux; then
+	    install_package openstack-common
+	else
+            install_package radvd
+	fi
     fi
     # install packages that are specific to plugin agent(s)
     if is_service_enabled q-agt q-dhcp q-l3; then

--- a/tools/fixup_stuff.sh
+++ b/tools/fixup_stuff.sh
@@ -202,5 +202,7 @@ fi
 # on python-virtualenv), first install the distro python-virtualenv
 # to satisfy any dependencies then use pip to overwrite it.
 
-install_package python-virtualenv
+if !is_clearlinux; then
+    install_package python-virtualenv
+fi
 pip_install -U --force-reinstall virtualenv


### PR DESCRIPTION
If finally all starlingx dependencies are in stx-basic, then every install in the devstack script should be "swupd bundle-add stx-basic", which is not reasonable. That's why this patch will skip all those installs in the script. 

All the packages should be installed in bundles and no package
install/uninstall needed.

Signed-off-by: Yan Chen <yan.chen@intel.com>