### PR TITLE
Add --buffered flag for outfilter.py.

### DIFF
--- a/tools/outfilter.py
+++ b/tools/outfilter.py
@@ -50,7 +50,7 @@ def main():
     opts = get_options()
     outfile = None
     if opts.outfile:
-        outfile = open(opts.outfile, 'a', 0)
+        outfile = open(opts.outfile, 'a')
 
     # Otherwise fileinput reprocess args as files
     sys.argv = []

--- a/tools/worlddump.py
+++ b/tools/worlddump.py
@@ -235,7 +235,7 @@ def main():
     opts = get_options()
     fname = filename(opts.dir, opts.name)
     print("World dumping... see %s for details" % fname)
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')
     with open(fname, 'w') as f:
         os.dup2(f.fileno(), sys.stdout.fileno())
         disk_space()


### PR DESCRIPTION
As non-buffered text I/O will cause error on Clearlinux.

Signed-off-by: Yan Chen <yan.chen@intel.com>