### PR TITLE
Use restart instead of start to start a service.

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -1569,7 +1569,7 @@ function _run_under_systemd {
     fi
 
     $SYSTEMCTL enable $systemd_service
-    $SYSTEMCTL start $systemd_service
+    $SYSTEMCTL restart $systemd_service
 }
 
 # Helper to remove the ``*.failure`` files under ``$SERVICE_DIR/$SCREEN_NAME``.


### PR DESCRIPTION
In case the service is already running.

Signed-off-by: Yan Chen <yan.chen@intel.com>