### PR TITLE
Modify python exec prefix for Clearlinux.

### DIFF
--- a/inc/python
+++ b/inc/python
@@ -49,7 +49,7 @@ function get_python_exec_prefix {
     fi
     $xtrace
 
-    if is_fedora || is_suse; then
+    if is_fedora || is_suse || is_clearlinux; then
         echo "/usr/bin"
     else
         echo "/usr/local/bin"


### PR DESCRIPTION
On Clearlinux the prefix for Python should be /usr/bin.

Signed-off-by: Yan Chen <yan.chen@intel.com>