### PR TITLE
Fix swupd_install exit from ret value 18 issue.

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -1339,7 +1339,13 @@ function swupd_install {
     [[ "$(id -u)" = "0" ]] && sudo="env"
     $sudo http_proxy="${http_proxy:-}" https_proxy="${https_proxy:-}" \
         no_proxy="${no_proxy:-}" \
-        swupd bundle-add "$@"
+	swupd bundle-add "$@"
+    ret=$?
+    if [[ "$ret" = "0" ]] || [[ "$ret" = "18" ]]; then
+        return 0
+    else
+        return $ret
+    fi
 }
 
 # Distro-agnostic package uninstaller


### PR DESCRIPTION
On Clearlinux, if a bundle is already existing, swupd bundle-add
will return 18. Modify the function swupd_install to handle this.

Signed-off-by: Yan Chen <yan.chen@intel.com>