### PR TITLE
Add code to pip install libvirt-python.

### DIFF
--- a/lib/nova_plugins/functions-libvirt
+++ b/lib/nova_plugins/functions-libvirt
@@ -82,6 +82,8 @@ function install_libvirt {
         pip_install_gr libvirt-python
     elif is_clearlinux; then
 	install_package openstack-common
+        pip_uninstall libvirt-python
+        pip_install_gr libvirt-python
     fi
 
     if [[ $DEBUG_LIBVIRT_COREDUMPS == True ]]; then


### PR DESCRIPTION
This pkg is not included in stx-basic now.
Once it is included in the bundle, we can abandon this patch.

Signed-off-by: Yan Chen <yan.chen@intel.com>