### PR TITLE
Add FORCE_LEGACY_PYTHON env for services started by systemd.

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -1497,6 +1497,9 @@ function write_user_unit_file {
     if [[ -n "$group" ]]; then
         iniset -sudo $unitfile "Service" "Group" "$group"
     fi
+    if is_clearlinux; then
+        iniset -sudo $unitfile "Service" "Environment" "FORCE_LEGACY_PYTHON=true"
+    fi
     iniset -sudo $unitfile "Install" "WantedBy" "multi-user.target"
 
     # changes to existing units sometimes need a refresh


### PR DESCRIPTION
Use python2 for the openstack services on Clearlinux.

Signed-off-by: Yan Chen <yan.chen@intel.com>